### PR TITLE
Make add-on compatible with concrete5 version 8.0.0

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -13,8 +13,8 @@ class Controller extends Package
 {
 
     protected $pkgHandle = 'asset_pipeline';
-    protected $appVersionRequired = '5.7.1';
-    protected $pkgVersion = '0.0.1';
+    protected $appVersionRequired = '8.0.0';
+    protected $pkgVersion = '0.0.2';
 
     public function getPackageName()
     {
@@ -25,6 +25,10 @@ class Controller extends Package
     {
         return t("Provides easy to use way to manage and build assets in concrete5.");
     }
+
+    protected $pkgAutoloaderRegistries = array(
+        'src' => '\Concrete\Package\AssetPipeline\Src',
+    );
 
     public function getPackageEntitiesPath()
     {
@@ -39,6 +43,7 @@ class Controller extends Package
             throw new Exception(t("You need to install the composer packages for this add-on before installation!"));
         }
 
+        $this->loadDependencies();
         $pkg = parent::install();
     }
 

--- a/controller.php
+++ b/controller.php
@@ -30,12 +30,6 @@ class Controller extends Package
         'src' => '\Concrete\Package\AssetPipeline\Src',
     );
 
-    public function getPackageEntitiesPath()
-    {
-        // Fix installation issues
-        return $this->getPackagePath() . '/' . DIRNAME_CLASSES . '/Entity';
-    }
-
     public function install()
     {
         $fs = new Filesystem();

--- a/src/Core/Original/Asset/CssAssetCore.php
+++ b/src/Core/Original/Asset/CssAssetCore.php
@@ -8,7 +8,7 @@ use Concrete\Core\Asset\Asset;
 use Concrete\Core\Html\Object\HeadLink;
 use Config;
 
-class CssAsset extends Asset
+class CssAssetCore extends Asset
 {
     /**
      * @var bool

--- a/src/Core/Original/Page/Theme/Theme.php
+++ b/src/Core/Original/Page/Theme/Theme.php
@@ -22,9 +22,6 @@ use Localization;
 /**
  * A page's theme is a pointer to a directory containing templates, CSS files and optionally PHP includes, images and JavaScript files.
  * Themes inherit down the tree when a page is added, but can also be set at the site-wide level (thereby overriding any previous choices.).
- *
- * @package Pages and Collections
- * @subpackages Themes
  */
 class Theme extends Object
 {

--- a/src/Core/Original/StyleCustomizer/Style/TypeStyle.php
+++ b/src/Core/Original/StyleCustomizer/Style/TypeStyle.php
@@ -6,9 +6,9 @@ use Concrete\Core\StyleCustomizer\Style\Style;
 
 use \Concrete\Core\StyleCustomizer\Style\Value\TypeValue;
 use \Concrete\Core\StyleCustomizer\Style\Value\ColorValue;
-use \Concrete\Core\StyleCustomizer\Style\ColorStyle;
+use \Concrete\Core\StyleCustomizer\Style\ColorStyle as ColorStyleOrg;
 use \Concrete\Core\StyleCustomizer\Style\Value\SizeValue;
-use \Concrete\Core\StyleCustomizer\Style\SizeStyle;
+use \Concrete\Core\StyleCustomizer\Style\SizeStyle as SizeStyleOrg;
 
 use Core;
 
@@ -174,7 +174,7 @@ class TypeStyle extends Style {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0];
-                $cv = ColorStyle::parse($value);
+                $cv = ColorStyleOrg::parse($value);
                 if ($cv instanceof ColorValue) {
                     $values[$matches[1]]->setColor($cv);
                 }
@@ -185,7 +185,7 @@ class TypeStyle extends Style {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0];
-                $sv = SizeStyle::parse($value);
+                $sv = SizeStyleOrg::parse($value);
                 if ($sv instanceof SizeValue) {
                     $values[$matches[1]]->setFontSize($sv);
                 }
@@ -196,7 +196,7 @@ class TypeStyle extends Style {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0];
-                $sv = SizeStyle::parse($value);
+                $sv = SizeStyleOrg::parse($value);
                 if ($sv instanceof SizeValue) {
                     $values[$matches[1]]->setLetterSpacing($sv);
                 }
@@ -207,7 +207,7 @@ class TypeStyle extends Style {
                     $values[$matches[1]] = new TypeValue($matches[1]);
                 }
                 $value = $rule->value->value[0]->value[0];
-                $sv = SizeStyle::parse($value);
+                $sv = SizeStyleOrg::parse($value);
                 if ($sv instanceof SizeValue) {
                     $values[$matches[1]]->setLineHeight($sv);
                 }

--- a/src/Core/Override/Asset/CssAssetOvrd.php
+++ b/src/Core/Override/Asset/CssAssetOvrd.php
@@ -3,9 +3,9 @@
 namespace Concrete\Core\Asset;
 
 use Concrete\Core\Support\Facade\Facade;
-use Concrete\Package\AssetPipeline\Src\Core\Original\Asset\CssAsset as CoreCssAsset;
+use Concrete\Package\AssetPipeline\Src\Core\Original\Asset\CssAssetCore;
 
-class CssAsset extends CoreCssAsset
+class CssAssetOvrd extends CssAssetCore
 {
 
     /**
@@ -37,7 +37,7 @@ class CssAsset extends CoreCssAsset
             ));
             $assetDir = Config::get('concrete.cache.directory');
 
-            $asset = new CssAsset();
+            $asset = new self();
             $asset->setAssetURL($relativePath);
             $asset->setAssetPath($assetDir . $relativePath);
             $asset->setCombinedAssetSourceFiles($sourceFiles);

--- a/src/Core/Override/Asset/JavascriptAssetOvrd.php
+++ b/src/Core/Override/Asset/JavascriptAssetOvrd.php
@@ -5,7 +5,7 @@ namespace Concrete\Core\Asset;
 use Concrete\Package\AssetPipeline\Src\Core\Original\Asset\JavascriptAsset as CoreJavascriptAsset;
 use Config;
 
-class JavascriptAsset extends CoreJavascriptAsset
+class JavascriptAssetOvrd extends CoreJavascriptAsset
 {
 
     /**

--- a/src/Core/Override/Page/Theme/ThemeOvrd.php
+++ b/src/Core/Override/Page/Theme/ThemeOvrd.php
@@ -8,7 +8,7 @@ use Core;
 use Environment;
 use Loader;
 
-class Theme extends CoreTheme
+class ThemeOvrd extends CoreTheme
 {
 
     const THEME_CUSTOMIZABLE_STYLESHEET_EXTENSION = '.less';

--- a/src/FilterProvider.php
+++ b/src/FilterProvider.php
@@ -20,7 +20,7 @@ class FilterProvider extends ServiceProvider
         $config = $this->app->make('config');
 
         // Register Less filter & variable value extractor
-        $this->app->bind('assets/filter/less', function ($app, $assets) use ($config) {
+        $this->app->bind('assets/filter/less', function ($app, $options) use ($config) {
             $lessf = new LessphpFilter(
                 array(
                     'cache_dir' => $config->get('concrete.cache.directory'),
@@ -32,6 +32,8 @@ class FilterProvider extends ServiceProvider
                 $lessf->setBasePath('/' . ltrim($app['app_relative_path'], '/'));
                 $lessf->setRelativeUrlPaths(true);
             }
+
+            $assets = $options['assets'];
 
             $variableList = $assets->getStyleSheetVariables();
             if (is_array($variableList)) {
@@ -49,7 +51,10 @@ class FilterProvider extends ServiceProvider
         });
 
         // Register SCSS filter & variable value extractor
-        $this->app->bind('assets/filter/scss', function ($app, $assets) use ($config) {
+        $this->app->bind('assets/filter/scss', function ($app, $options) use ($config) {
+
+            $assets = $options['assets'];
+
             // There does not seem to be a way to get the source maps to the
             // ScssPhp at the moment:
             // https://github.com/leafo/scssphp/issues/135
@@ -76,13 +81,19 @@ class FilterProvider extends ServiceProvider
         });
 
         // Register JShrink filter
-        $this->app->bind('assets/filter/jshrink', function ($app, $assets) {
+        $this->app->bind('assets/filter/jshrink', function ($app, $options) {
+
+            $assets = $options['assets'];
+
             $jsf = new JShrinkFilter();
             return $jsf;
         });
 
         // Register CssMin filter
-        $this->app->bind('assets/filter/cssmin', function ($app, $assets) {
+        $this->app->bind('assets/filter/cssmin', function ($app, $options) {
+
+            $assets = $options['assets'];
+
             $cmf = new CssMinFilter();
             return $cmf;
         });

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -126,11 +126,11 @@ class PackageServiceProvider extends ServiceProvider
         $dir = DIR_PACKAGES . '/' . $this->pkgHandle;
         $overrides = array(
             'Concrete\\Core\\Asset\\CssAsset'
-                => $dir . '/src/Core/Override/Asset/CssAsset.php',
+                => $dir . '/src/Core/Override/Asset/CssAssetOvrd.php',
             'Concrete\\Core\\Asset\\JavascriptAsset'
-                => $dir . '/src/Core/Override/Asset/JavascriptAsset.php',
+                => $dir . '/src/Core/Override/Asset/JavascriptAssetOvrd.php',
             'Concrete\\Core\\Page\\Theme\\Theme'
-                => $dir . '/src/Core/Override/Page/Theme/Theme.php',
+                => $dir . '/src/Core/Override/Page/Theme/ThemeOvrd.php',
             'Concrete\\Core\\StyleCustomizer\\Preset'
                 => $dir . '/src/Core/Override/StyleCustomizer/Preset.php',
             'Concrete\\Core\\StyleCustomizer\\Stylesheet'

--- a/src/Service/Assets.php
+++ b/src/Service/Assets.php
@@ -85,6 +85,16 @@ class Assets
         return $this->compileCssToCache($assets, $options);
     }
 
+    /**
+     * Alias for the method javascript
+     *
+     * @param array $assets
+     * @param array $options
+     */
+    public function js($assets, array $options = null){
+        return $this->javascript($assets, $options);
+    }
+
     public function javascript($assets, array $options = null)
     {
         $path = $this->javascriptPath($assets, $options);

--- a/src/Service/Assets.php
+++ b/src/Service/Assets.php
@@ -192,12 +192,13 @@ class Assets
         $fm = $factory->getFilterManager();
         $assets = new AssetCollection();
 
-        // Set the filters to he filter manager
+        // Set the filters to the filter manager
         foreach ($fsr->getAllFilterSettings() as $key => $flt) {
             if (!$this->app->bound('assets/filter/' . $key)) {
                 throw new Exception(t("Filter not available for key: %s", $key));
             }
-            $fm->set($key, $this->app->make('assets/filter/' . $key, $this));
+            $filter = $this->app->make('assets/filter/' . $key, array('assets' => $this));
+            $fm->set($key, $filter);
         }
 
         // Create the asset and push it into the AssetCollection


### PR DESCRIPTION
Fix various issues with concrete5 version 8.0.0:
- Fix  -> Illuminate\Container\Container::make() must be of the type array, object given, called in packages\asset_pipeline\src\Service\Assets.php
- Fix various - "Can not declare class" ... exceptions
- Fix AnnotationException related with **@package** annotations and Doctrine
- Add **alias method 'js'** for **Asset::javascript** like described in the readme
- **Update to version 8.0.0**